### PR TITLE
Parametrize the refresh time between fact update

### DIFF
--- a/config.pl.ex
+++ b/config.pl.ex
@@ -2,6 +2,9 @@
 
 :- module(config, [config/2]).
 
+%% world setting
+config(refresh_time, 300).
+
 %% settings for irc.pl module
 
 config(irc_server, 'irc.freenode.org').

--- a/world.pl
+++ b/world.pl
@@ -7,6 +7,7 @@
                  ]).
 
 :- use_module(library(persistency)).
+:- use_module(config).
 
 :- dynamic fact/2, longterm/1, fact_updater/1, fact_deducer/1, fact_solver/1, last_gen/1.
 
@@ -140,7 +141,8 @@ forever :-
     % Keep only the previous generation of facts
     Prev is Gen - 2,
     retractall(fact(Prev,_)),
-    sleep(300),
+    config(refresh_time, RefreshTime),
+    sleep(RefreshTime),
     fail.
 
 %% world.pl ends here


### PR DESCRIPTION
The refresh time between fact update is hard coded to 5mins.
Either for testing purpose (poss. lower value) or for production
purpose (poss. higher value) we might want to change that value.

Hence moving this value into the config.pl file