### PR TITLE
Only answer on public channel when asked

### DIFF
--- a/discuss.pl
+++ b/discuss.pl
@@ -18,13 +18,11 @@ process_message(Id, Server, "PRIVMSG", Params, Text) :-
     private_message(Id, CleanList, Nick).
 
 process_message(Id, Server, "PRIVMSG", [Param|_], Text) :-
-    split_string(Text, " ", "@:.,!", S),
+    split_string(Text, " ", "@:.,!", [BotName|S]),
     config(irc_nick, IrcNick),
-    member(IrcNick, S),
-    delete(S, IrcNick, CleanList1),
-    delete(CleanList1, "", CleanList),
+    IrcNick == BotName,
     prefix_id(Server, Nick, _, _),
-    public_message(Id, CleanList, Nick, Param).
+    public_message(Id, S, Nick, Param).
 
 process_message(_, _, _, _, _).
 


### PR DESCRIPTION
The behavior of the bot today:

  * jdoe> botsito hi
  * botsito> hi jdoe
  * jdoe> I don't know who is botsito
  * botsito> jdoe: not understood. Use 'help' to list what I understand.

The purpose of this PR is for sbot to only answer message when he is
directly asked. By directly ask it is meant MSG = botsito <PARAMS>