### PR TITLE
install: httpd + mod_userdir as part of the deployment

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -12,6 +12,8 @@ The `hosts` file looks like:
 botsito.example.com ansible_python_interpreter=/usr/bin/python3
 ```
 
+Before running the playbook, one needs to install the needed modules: `ansible-galaxy install -r install-roles.yml -p roles`
+
 Then simply run: `ansible-playbook -i hosts install-playbook.yml -e @settings.yml`
 
 At the end of the run, you will have sbot running on a tmux session on your target host.

--- a/install/group_vars/all
+++ b/install/group_vars/all
@@ -1,0 +1,1 @@
+httpd_mod_userdir_enabled: True

--- a/install/install-playbook.yml
+++ b/install/install-playbook.yml
@@ -15,15 +15,28 @@
           - fedpkg
           - spectool
 
+      - include_role:
+          name: httpd
+
       - name: Make botsito part of the mock group
         user:
           name: botsito
           comment: "Botsito el bot mas bonito"
           groups: mock
 
+      - name: Set $HOME to 701 for mod_userdir
+        file:
+          path: /home/botsito
+          mode: '0701'
+
       become: True
 
     - block:
+      - name: Create the public_html dir
+        file:
+          path: ~/public_html
+          state: directory
+
       - name: Create the ~/.ssh dir
         file:
           path: ~/.ssh

--- a/install/install-roles.yml
+++ b/install/install-roles.yml
@@ -1,0 +1,2 @@
+- src: https://github.com/redhat-cip/ansible-role-httpd
+  name: httpd


### PR DESCRIPTION
The install process now install and configures httpd + mod_userdir.
So the user can leverage workspace_url in sbot config.