### PR TITLE
Use assertz when storing long term facts.

### DIFF
--- a/world.pl
+++ b/world.pl
@@ -40,7 +40,7 @@ store_longterm_fact(Fact) :-
     !.
 
 store_longterm_fact(Fact) :-
-    asserta(longterm(Fact)),
+    assertz(longterm(Fact)),
     save.
 
 remove_longterm_fact(Fact) :-


### PR DESCRIPTION
The long_term_fact should be a FIFO stack. It currently behaves as a
LIFO stack.

The long_term_fact stack is meant to store action that will be done
asynchronously. Let say I run

> botsito: dci sync OSP12
> botsito: dci sync OSP13

The bot would answer in the following way

** [DCI] Syncing of OSP13: failure
** [DCI] Syncing of OSP12: failure

OSP13 being dealt with first, when the user actually specified OSP12
first.