### PR TITLE
Check items on closing issues

### DIFF
--- a/github.pl
+++ b/github.pl
@@ -22,6 +22,12 @@ update_github_facts(Gen) :-
     merge_status(Dict.merged, Status),
     store_fact(Gen, github_pr_merged(Owner, Project, Pr, Status)).
 
+update_github_facts(Gen) :-
+    config(github, [Owner, Project]),
+    github_issues(Owner, Project, Issues),
+    member(Issue, Issues),
+    store_fact(Gen, github_issue(Owner, Project, Issue.id, Issue.html_url, Issue.title, Issue.state, Issue.user.login)).
+
 merge_status(false, no).
 merge_status(true, yes).
 
@@ -36,6 +42,11 @@ deduce_github_facts(Gen) :-
     get_old_fact(github_pr_sha(Owner, Project, Pr, OldSha)),
     Sha \== OldSha,
     store_fact(Gen, github_updated_pr(Owner, Project, Pr, Sha, OldSha)).
+
+deduce_github_facts(Gen) :-
+    get_fact(github_issue(Owner, Project, Id, Url, Title, "closed", Reporter)),
+    get_old_fact(github_issue(_, _, Id, _, _, "open", _)),
+    store_fact(Gen, github_closed_issue(Owner, Project, Id, Url, Title, "closed", Reporter)).
 
 :- add_fact_deducer(github:deduce_github_facts).
 
@@ -58,6 +69,12 @@ github_solver(_) :-
     format(string(Text), "Github PR ~w merged", [Url]),
     notify(Text, Context).
 
+github_solver(_) :-
+    get_fact(github_closed_issue(Owner, Project, _, Url, Title, _, _)),
+    format(string(Text), "** [~w/~w] Issue \"~w\" has been closed (~w)", [Owner, Project, Title, Url]),
+    format(string(Repo), "~w/~w", [Owner, Project]),
+    notification(["github", Repo, "closed_issue"], Text).
+
 :- add_fact_solver(github:github_solver).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -65,9 +82,13 @@ github_solver(_) :-
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % github help
-github_answer(List, _, "github trackpr <owner> <project> <pr>\ngithub untrackpr <owner> <project> <pr>\ngithub trackpr: list all the tracked PR") :-
-    member("github", List),
-    member("help", List).
+github_answer(["github", "help"], _,
+           ["Available commands:\n",
+            bold("github trackpr"), ": track the speficied PR.\n",
+            bold("github untrackpr"), ": untrack the specified PR.\n",
+            "Available notifications\n",
+            bold("github <Owner/Project> closed_issue")
+           ]).
 
 % github trackpr ansible ansible 35917
 github_answer(["github", "trackpr", Owner, Project, Pr], Context, Answer) :-

--- a/githublib.pl
+++ b/githublib.pl
@@ -1,7 +1,7 @@
 %% -*- prolog -*-
 
 :- module(githublib,
-          [github_pr/4, github_prs/3
+          [github_pr/4, github_prs/3, github_issues/3
           ]).
 
 :- use_module(library(http/http_client)).
@@ -22,6 +22,10 @@ github_pr(Owner, Project, Pr, Dict) :-
 
 github_prs(Owner, Project, Dict) :-
     format(atom(Path), '/repos/~w/~w/pulls', [Owner, Project]),
+    github_json(Path, Dict).
+
+github_issues(Owner, Project, Dict) :-
+    format(atom(Path), '/repos/~w/~w/issues?state=all', [Owner, Project]),
     github_json(Path, Dict).
 
 %% githublib.pl ends here


### PR DESCRIPTION
This PR contains two commits.

The first one is to integrate new facts (github_issue and github_closed_issue).
The second one is to take automatic action of closing trello checklists items when an issue that was listed is closed.