### PR TITLE
Irc: Send to proper user even after nick change

### DIFF
--- a/discuss.pl
+++ b/discuss.pl
@@ -7,6 +7,7 @@
 :- use_module(config).
 :- use_module(utils).
 :- use_module(world).
+:- use_module(irc).
 
 :- dynamic answerer/1.
 
@@ -134,7 +135,8 @@ answer(List, [_,Nick|_], Answer) :-
     member(Elt, List),
     string_upper(Elt, UpperElt),
     member(UpperElt, ["HI", "HELLO", "SALUT", "BONJOUR", "HOLA", "HEY", "MORNING"]),
-    format(string(Answer), "~w ~w", [Elt, Nick]),
+    get_latest_nick(Nick, CurrentNick),
+    format(string(Answer), "~w ~w", [Elt, CurrentNick]),
     !.
 
 answer([Elt|_], Context, Answer) :-
@@ -161,11 +163,13 @@ answer(_, Context, Answer) :-
     add_prefix(Context, "not understood. Use 'help' to list what I understand.", Answer).
 
 add_prefix([_, Nick, _], [Text|Rest], [PrefixedText,Text|Rest]) :-
-    format(string(PrefixedText), "~w: ", [Nick]),
+    get_latest_nick(Nick, CurrentNick),
+    format(string(PrefixedText), "~w: ", [CurrentNick]),
     !.
 
 add_prefix([_, Nick, _], Text, PrefixedText) :-
-    format(string(PrefixedText), "~w: ~w", [Nick, Text]),
+    get_latest_nick(Nick, CurrentNick),
+    format(string(PrefixedText), "~w: ~w", [CurrentNick, Text]),
     !.
 
 add_prefix(_, Text, Text).

--- a/irc.pl
+++ b/irc.pl
@@ -1,10 +1,13 @@
 %% -*- prolog -*-
 
-:- module(irc, []).
+:- module(irc, [get_latest_nick/2]).
+
+:- dynamic nick_rename/2.
 
 :- use_module(library(irc_client)).
 :- use_module(discuss).
 :- use_module(config).
+:- use_module(world).
 
 :- initialization
    run.
@@ -20,7 +23,7 @@
 % must make sure that your module exports the event predicates that you want to
 % use with assert_handlers/2.
 
-:- assert_handlers(irc, [irc:output, irc:echo_connected]).
+:- assert_handlers(irc, [irc:output, irc:nick_change, irc:echo_connected]).
 
 
 % The next two predicates below (output/1 and echo_connected/1) are the actual
@@ -33,20 +36,45 @@
 % has been established when it reaches IRC message code 352.
 
 output(Id-Msg) :-
-	% This is the basic format of an incoming server message. It is a compound
-	% term of the format: msg(Server, Code, Params, Text), or in other words,
-	% msg(string, string, list(string), string)
-	% The third argument is a variable list of strings that represent specific
-	% IRC parameters
+    % This is the basic format of an incoming server message. It is a compound
+    % term of the format: msg(Server, Code, Params, Text), or in other words,
+    % msg(string, string, list(string), string)
+    % The third argument is a variable list of strings that represent specific
+    % IRC parameters
     Msg = msg(Server, Code, Params, Text),
     discuss:process_message(Id, Server, Code, Params, Text).
 
+nick_change(_-Msg) :-
+    Msg = msg(Server, "NICK", _, Text),
+    split_string(Server, "!", "", [OldNick|_]),
+    string_codes(NewNick, Text),
+    record_nick_change(OldNick, NewNick).
+
 echo_connected(Id-Msg) :-
-	% Every incoming message relayed by the server takes the form of a pair ...
-	% Id-Msg. The Id is the aliased Id of the connection when the thread for it
-	% is created. The Msg part of the pair is the actual message itself.
-	Msg = msg(Server, "352", _, _),
-	format("Successfully connected to ~s on ~s~n", [Server,Id]).
+    % Every incoming message relayed by the server takes the form of a pair ...
+    % Id-Msg. The Id is the aliased Id of the connection when the thread for it
+    % is created. The Msg part of the pair is the actual message itself.
+    Msg = msg(Server, "352", _, _),
+    format("Successfully connected to ~s on ~s~n", [Server,Id]).
+
+record_nick_change(_, NewNick) :-
+    % In order to avoid infinite loop, n -> n1, n1 -> n2, n2 -> n it is ensured
+    % that if a fact already exist with new nick it is first removed. Leading to
+    % n1 -> n2, n2 -> n
+    get_midterm_fact(nick_rename(NewNick, _)),
+    remove_midterm_fact(nick_rename(NewNick, _)),
+    !.
+
+record_nick_change(OldNick, NewNick) :-
+    % Store every change name n -> n1, n1 -> n2
+    store_midterm_fact(nick_rename(OldNick, NewNick)).
+
+get_latest_nick(OldNick, CurrentNick) :-
+    get_midterm_fact(nick_rename(OldNick, X)),
+    get_latest_nick(X, CurrentNick),
+    !.
+
+get_latest_nick(Nick, Nick).
 
 run :-
     thread_create(connect, _, [detached(true), alias(conn)]).


### PR DESCRIPTION
This commit allows for sbot to answer to proper user even
after he has changed his nick name once or multiple times.

If user1 asks for a command, change his nick to user2 then user3, sbot
will answer to user3.