### PR TITLE
Do not check for DLRN file for OSP10

### DIFF
--- a/tools/health_puddle.sh
+++ b/tools/health_puddle.sh
@@ -55,7 +55,7 @@ OSP_VERSION=$(echo ${PUDDLE_URL} | sed 's#.*/\(.*\).0-RHEL-7/.*$#\1#')
 
 check_status
 
-if [[ $OSP_VERSION -ge 10 ]]; then
+if [[ $OSP_VERSION -ge 11 ]]; then
     check_dlrn_data
 fi
 


### PR DESCRIPTION
Upstream Newton has been EOL, leading to no more commit.yml attached to
an OSP10 puddle.

Hence, the check is bumped to OSP11 for commit.yml