### PR TITLE
Ensure puddle are healthy for sync notif

### DIFF
--- a/dci.pl
+++ b/dci.pl
@@ -75,6 +75,7 @@ dci_solver(_) :-
     get_fact(puddle_info(Topic, _, "latest", Puddle)),
     split_string(NewComponent, " ", "", [_, ComponentPuddle]),
     ComponentPuddle \== Puddle,
+    not(get_fact(puddle_unhealthy(Topic, _, "latest", Puddle, _))),
     format(string(Text), "** DCI out of sync for ~w. DCI version: ~w | Puddle available: ~w", [Topic, ComponentPuddle, Puddle]),
     % notify only every 60 mn (12 x 5) to avoid flooding the chan every 5 mn
     notification(["dci", Product, Topic, "out_of_sync"], Text, 12).

--- a/tools/health_puddle.sh
+++ b/tools/health_puddle.sh
@@ -50,10 +50,22 @@ function check_containers {
     fi
 }
 
+function check_embargo {
+    linckchecker ${PUDDLE_URL}/EMBARGOED
+
+    if [[ $? -eq 1 ]]; then
+        echo "EMBARGOED: Not under embargo"
+    else
+        echo "EMBARGOED: Puddle under embargo"
+        exit 1
+    fi
+}
+
 PUDDLE_URL=$1
 OSP_VERSION=$(echo ${PUDDLE_URL} | sed 's#.*/\(.*\).0-RHEL-7/.*$#\1#')
 
 check_status
+check_embargo
 
 if [[ $OSP_VERSION -ge 10 ]]; then
     check_dlrn_data


### PR DESCRIPTION
As of now, when a new puddle is emitted, even if it is unhealthy it
triggers an out of sync notification.

out_of_sync notification means that a new healthy (ready to use) puddle
is avaiable for sync/use. This wasn't ensure up until now.